### PR TITLE
Add .gitignore with Rust and editor/OS rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Build artifacts
+/target/
+/debug/
+**/*.rs.bk
+*.pdb
+**/mutants.out*/
+
+# IDEs and editors
+.idea/
+.vscode/
+*~
+*.sw?
+
+# OS generated files
+.DS_Store
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+


### PR DESCRIPTION
## Summary
- add a new `.gitignore` to ignore Rust build directories and backup files
- exclude common editor temp files and OS artifacts

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687fde78da44832b9358136cef09dbeb