### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test

--- a/importer/src/bin/backend.rs
+++ b/importer/src/bin/backend.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use std::path::PathBuf;
 use std::error::Error;
+use std::path::PathBuf;
 
 /// Command line arguments for the backend tool
 #[derive(Parser, Debug)]


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `cargo fmt`, `cargo clippy`, and `cargo test`
- minor formatting update to `backend.rs`

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687fe86ac74c832bb5562d63e9f57a57