### PR TITLE
Add Etherscan transaction fetch

### DIFF
--- a/importer/src/blockchain.rs
+++ b/importer/src/blockchain.rs
@@ -1,8 +1,12 @@
 use std::env;
-use std::fs;
 use std::error::Error;
+use std::fs;
 
-use ethers::providers::{Provider, Http};
+use ethers::{
+    etherscan::Client as EtherscanClient,
+    providers::{Http, Provider},
+    types::{Address, Chain, H256, U256},
+};
 use serde::Deserialize;
 
 /// Configuration for connecting to the Arbitrum network.
@@ -31,4 +35,52 @@ impl Config {
 pub async fn provider(cfg: &Config) -> Result<Provider<Http>, Box<dyn Error>> {
     let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
     Ok(provider)
+}
+
+/// Simplified transaction information returned by [`fetch_transactions`].
+#[derive(Clone, Debug)]
+pub struct Transaction {
+    pub hash: H256,
+    pub block_number: u64,
+    pub timestamp: u64,
+    pub from: Address,
+    pub to: Option<Address>,
+    pub value: U256,
+}
+
+/// Retrieve all normal transactions for the given address using the Etherscan API.
+pub async fn fetch_transactions(address: Address) -> Result<Vec<Transaction>, Box<dyn Error>> {
+    // use optional API key from environment if provided
+    let client = EtherscanClient::new_from_opt_env(Chain::Arbitrum)?;
+    let txs = client.get_transactions(&address, None).await?;
+    let mut result = Vec::new();
+
+    for tx in txs {
+        let hash = match tx.hash.value().copied() {
+            Some(hash) => hash,
+            None => continue, // skip malformed entries
+        };
+        let from = match tx.from.value().copied() {
+            Some(addr) => addr,
+            None => continue,
+        };
+
+        let block_number = tx
+            .block_number
+            .as_number()
+            .map(|n| n.as_u64())
+            .unwrap_or_default();
+        let timestamp = tx.time_stamp.parse::<u64>().unwrap_or_default();
+
+        result.push(Transaction {
+            hash,
+            block_number,
+            timestamp,
+            from,
+            to: tx.to,
+            value: tx.value,
+        });
+    }
+
+    Ok(result)
 }


### PR DESCRIPTION
## Summary
- expose a new `Transaction` struct
- add `fetch_transactions` to query Etherscan for normal txs

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687fedf2b720832b92b90021ad052f33