### PR TITLE
Add ERC-20 transfer tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ The workspace contains a single crate with a binary called `backend`. You can ru
 cargo run -p arb-gnucash-importer --bin backend
 ```
 
+The output JSON contains normal transactions along with any ERC-20 token transfers.
+
 ## Planned features
 
 - Fetch transactions from the Arbitrum blockchain.
 - Export retrieved data into a format that can be imported by GnuCash.
+- Track ERC-20 token transfers associated with each transaction.
 

--- a/importer/src/bin/backend.rs
+++ b/importer/src/bin/backend.rs
@@ -3,6 +3,8 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use arb_gnucash_importer::blockchain::{self, Config};
+use ethers::types::Address;
+use std::fs;
 
 /// Command line arguments for the backend tool
 #[derive(Parser, Debug)]
@@ -26,8 +28,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // initialize logging from log4rs config file
     log4rs::init_file("log4rs.yml", Default::default()).expect("failed to init logger");
 
-    let _args = Args::parse();
+    let args = Args::parse();
     let cfg = Config::load(None)?;
     let _provider = blockchain::provider(&cfg).await?;
+
+    let address: Address = args.address.parse()?;
+    let txs = blockchain::fetch_transactions(address).await?;
+    let json = serde_json::to_string_pretty(&txs)?;
+    fs::write(args.output, json)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- track ERC-20 token transfers in blockchain module
- write transactions + transfers to file in backend CLI
- document token transfer support
- test ERC-20 transfer struct

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ff98f0484832b8ea7de1a73ba07c5