### PR TITLE
Add tagged address support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust tool for importing transactions from the Arbitrum network into GnuCash. A
 
 ## Prerequisites
 
-This project uses the nightly Rust toolchain. Ensure you have [`rustup`](https://rustup.rs/) installed and the nightly toolchain available. The repo includes a `rust-toolchain.toml` file which will automatically configure the correct toolchain when running Cargo commands.
+This project uses the nightly Rust toolchain. Ensure you have [rustup](https://rustup.rs/) installed and the nightly toolchain available. The repo includes a `rust-toolchain.toml` file which will automatically configure the correct toolchain when running Cargo commands.
 
 ## Running the binary
 
@@ -22,3 +22,11 @@ The output JSON contains normal transactions along with any ERC-20 token transfe
 - Export retrieved data into a format that can be imported by GnuCash.
 - Track ERC-20 token transfers associated with each transaction.
 
+## Address tags
+
+You can provide a mapping of addresses to service names using the `--tags` option. The file may be TOML, JSON or YAML. Example `tags.yml`:
+
+```yaml
+0x1111111111111111111111111111111111111111: Alice
+0x2222222222222222222222222222222222222222: Bob
+```

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 ethers = "2"
+toml = "0.8"


### PR DESCRIPTION
## Summary
- allow parsing tags file in JSON/TOML/YAML
- store optional `from_tag`/`to_tag` for each transaction
- apply tags from CLI using `--tags`
- document tags usage in README

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688041acc6e8832bb6d353801ffea581