### PR TITLE
Add CSV export support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 name = "arb-gnucash-importer"
 version = "1.0.0"
 dependencies = [
+ "chrono",
  "clap",
+ "csv",
  "ethers",
  "log4rs",
  "serde",
@@ -641,6 +643,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -14,3 +14,5 @@ serde_json = "1"
 serde_yaml = "0.9"
 ethers = "2"
 toml = "0.8"
+csv = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/importer/src/bin/backend.rs
+++ b/importer/src/bin/backend.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use arb_gnucash_importer::blockchain::{self, apply_tags, Config, Tags};
+use arb_gnucash_importer::export::{self, write_csv};
 use ethers::types::Address;
-use std::fs;
 
 /// Command line arguments for the backend tool
 #[derive(Parser, Debug)]
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let tags = Tags::load(tags_path)?;
         apply_tags(&mut txs, &tags);
     }
-    let json = serde_json::to_string_pretty(&txs)?;
-    fs::write(args.output, json)?;
+    let gnucash_txs = export::from_chain(address, &txs);
+    write_csv(&args.output, &gnucash_txs)?;
     Ok(())
 }

--- a/importer/src/export.rs
+++ b/importer/src/export.rs
@@ -1,0 +1,107 @@
+use chrono::{NaiveDate, NaiveDateTime};
+use csv::Writer;
+use ethers::types::Address;
+use ethers::utils::format_units;
+use std::error::Error;
+use std::fs::File;
+use std::path::Path;
+
+use crate::blockchain;
+
+/// Transaction format used for GnuCash CSV exports
+#[derive(Debug)]
+pub struct Transaction {
+    pub date: NaiveDate,
+    pub description: String,
+    pub account: String,
+    pub deposit: Option<f64>,
+    pub withdrawal: Option<f64>,
+}
+
+fn value_to_f64(value: ethers::types::U256) -> f64 {
+    format_units(value, 18)
+        .unwrap_or_else(|_| "0".to_string())
+        .parse::<f64>()
+        .unwrap_or(0.0)
+}
+
+/// Convert blockchain transactions into GnuCash CSV transactions
+pub fn from_chain(address: Address, txs: &[blockchain::Transaction]) -> Vec<Transaction> {
+    txs.iter()
+        .map(|tx| {
+            let dt = NaiveDateTime::from_timestamp_opt(tx.timestamp as i64, 0)
+                .unwrap_or_else(|| NaiveDateTime::from_timestamp(tx.timestamp as i64, 0));
+            let date = dt.date();
+            let amount = value_to_f64(tx.value);
+            let (deposit, withdrawal, description, account) = if tx.to == Some(address) {
+                let desc = tx
+                    .from_tag
+                    .as_deref()
+                    .map(|t| format!("from {t}"))
+                    .unwrap_or_else(|| "deposit".to_string());
+                let acc = tx.from_tag.clone().unwrap_or_else(|| "Unknown".to_string());
+                (Some(amount), None, desc, acc)
+            } else {
+                let desc = tx
+                    .to_tag
+                    .as_deref()
+                    .map(|t| format!("to {t}"))
+                    .unwrap_or_else(|| "withdrawal".to_string());
+                let acc = tx.to_tag.clone().unwrap_or_else(|| "Unknown".to_string());
+                (None, Some(amount), desc, acc)
+            };
+
+            Transaction {
+                date,
+                description,
+                account,
+                deposit,
+                withdrawal,
+            }
+        })
+        .collect()
+}
+
+/// Write the provided transactions to `path` in CSV format compatible with GnuCash
+pub fn write_csv(path: &Path, txs: &[Transaction]) -> Result<(), Box<dyn Error>> {
+    let file = File::create(path)?;
+    let mut wtr = Writer::from_writer(file);
+    wtr.write_record(["Date", "Description", "Account", "Deposit", "Withdrawal"])?;
+    for tx in txs {
+        wtr.write_record([
+            tx.date.to_string(),
+            tx.description.clone(),
+            tx.account.clone(),
+            tx.deposit.map(|v| v.to_string()).unwrap_or_default(),
+            tx.withdrawal.map(|v| v.to_string()).unwrap_or_default(),
+        ])?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blockchain::Transaction as ChainTx;
+    use ethers::types::{H256, U256};
+
+    #[test]
+    fn conversion_sets_fields() {
+        let chain_tx = ChainTx {
+            hash: H256::zero(),
+            block_number: 1,
+            timestamp: 0,
+            from: Address::repeat_byte(0x11),
+            to: Some(Address::repeat_byte(0x22)),
+            value: U256::from(10u64.pow(18)),
+            from_tag: Some("alice".to_string()),
+            to_tag: Some("bob".to_string()),
+            transfers: Vec::new(),
+        };
+        let res = from_chain(Address::repeat_byte(0x22), &[chain_tx]);
+        assert_eq!(res[0].deposit.unwrap(), 1.0);
+        assert!(res[0].withdrawal.is_none());
+        assert_eq!(res[0].account, "alice");
+    }
+}

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod blockchain;
+pub mod export;


### PR DESCRIPTION
## Summary
- support generating GnuCash CSV output
- export blockchain data into CSV transactions
- write CSV from the CLI instead of JSON

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68810adeab04832b8ea54dfa45c1125d