### PR TITLE
Add multi-format config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ The output JSON contains normal transactions along with any ERC-20 token transfe
 
 ## Configuration
 
-RPC endpoint information is read from a small configuration file. An example
-is provided at [examples/config.sample.toml](examples/config.sample.toml).
-Copy this file to `config.toml` (or another path of your choice) and adjust the
-`rpc_url` value to point at your preferred Arbitrum RPC provider.
+RPC endpoint information is read from a small configuration file. Examples are
+provided at [examples/config.sample.toml](examples/config.sample.toml) and
+[examples/config.sample.yml](examples/config.sample.yml). Copy one of these
+files to `config.toml` or `config.yml` (or another path of your choice) and
+adjust the `rpc_url` value to point at your preferred Arbitrum RPC provider.
 
 ## Planned features
 

--- a/examples/config.sample.yml
+++ b/examples/config.sample.yml
@@ -1,0 +1,2 @@
+# RPC URL for connecting to the Arbitrum network
+rpc_url: https://arb1.arbitrum.io/rpc


### PR DESCRIPTION
## Summary
- support config in TOML, YAML or JSON
- document multi-format support in README
- add YAML config sample
- test config loading with TOML and YAML

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688116d14578832b8ae4e329b52dc3dd