### PR TITLE
Add etherscan client helper

### DIFF
--- a/importer/src/bin/backend.rs
+++ b/importer/src/bin/backend.rs
@@ -31,9 +31,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let cfg = Config::load(None)?;
     let _provider = blockchain::provider(&cfg).await?;
+    let client = blockchain::etherscan_client(&cfg)?;
 
     let address: Address = args.address.parse()?;
-    let mut txs = blockchain::fetch_transactions(address).await?;
+    let mut txs = blockchain::fetch_transactions(&client, address).await?;
     if let Some(tags_path) = args.tags.as_deref() {
         let tags = Tags::load(tags_path)?;
         apply_tags(&mut txs, &tags);


### PR DESCRIPTION
## Summary
- add `etherscan_client` helper
- pass client reference into `fetch_transactions`
- update backend to use the helper
- test that the client parameter is respected

## Testing
- `cargo test --all --locked`

------
https://chatgpt.com/codex/tasks/task_e_688116d574a0832b828ddac907ae614a