### PR TITLE
Add sample config lines for Etherscan API key

### DIFF
--- a/examples/config.sample.toml
+++ b/examples/config.sample.toml
@@ -1,2 +1,6 @@
 # RPC URL for connecting to the Arbitrum network
 rpc_url = "https://arb1.arbitrum.io/rpc"
+
+# Optional Etherscan API key (omit if the `ARBISCAN_API_KEY` environment
+# variable is set)
+# etherscan_api_key = "YOUR-KEY-HERE"

--- a/examples/config.sample.yml
+++ b/examples/config.sample.yml
@@ -1,2 +1,6 @@
 # RPC URL for connecting to the Arbitrum network
 rpc_url: https://arb1.arbitrum.io/rpc
+
+# Optional Etherscan API key (omit if the `ARBISCAN_API_KEY` environment
+# variable is set)
+# etherscan_api_key: "YOUR-KEY-HERE"


### PR DESCRIPTION
## Summary
- demonstrate how to provide `etherscan_api_key` in config files
- note that the key isn't needed when `ARBISCAN_API_KEY` is set

## Testing
- `cargo +nightly test`

------
https://chatgpt.com/codex/tasks/task_e_68812257173c832bb58fd0b4d5b4d218