### PR TITLE
Add optional etherscan API key support

### DIFF
--- a/examples/config.sample.toml
+++ b/examples/config.sample.toml
@@ -1,2 +1,4 @@
 # RPC URL for connecting to the Arbitrum network
 rpc_url = "https://arb1.arbitrum.io/rpc"
+# Optional API key for Etherscan queries
+# etherscan_api_key = "YOUR_KEY"

--- a/examples/config.sample.yml
+++ b/examples/config.sample.yml
@@ -1,2 +1,4 @@
 # RPC URL for connecting to the Arbitrum network
 rpc_url: https://arb1.arbitrum.io/rpc
+# Optional API key for Etherscan queries
+# etherscan_api_key: YOUR_KEY


### PR DESCRIPTION
## Summary
- add `etherscan_api_key` field to `Config`
- create etherscan client using the key when provided
- document the optional key in sample configs

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6881225a17a8832b8fb1401ac765b4be