### PR TITLE
Add token split exports

### DIFF
--- a/importer/src/export.rs
+++ b/importer/src/export.rs
@@ -8,72 +8,98 @@ use std::path::Path;
 
 use crate::blockchain;
 
-/// Transaction format used for GnuCash CSV exports
+/// A single split in a transaction for GnuCash CSV exports
 #[derive(Debug)]
-pub struct Transaction {
+pub struct Split {
     pub date: NaiveDate,
     pub description: String,
     pub account: String,
-    pub deposit: Option<f64>,
-    pub withdrawal: Option<f64>,
+    pub commodity: String,
+    pub value: f64,
+    pub amount: f64,
 }
 
-fn value_to_f64(value: ethers::types::U256) -> f64 {
-    format_units(value, 18)
+fn value_to_f64(value: ethers::types::U256, decimals: u32) -> f64 {
+    format_units(value, decimals)
         .unwrap_or_else(|_| "0".to_string())
         .parse::<f64>()
         .unwrap_or(0.0)
 }
 
 /// Convert blockchain transactions into GnuCash CSV transactions
-pub fn from_chain(address: Address, txs: &[blockchain::Transaction]) -> Vec<Transaction> {
-    txs.iter()
-        .map(|tx| {
-            let dt = NaiveDateTime::from_timestamp_opt(tx.timestamp as i64, 0)
-                .unwrap_or_else(|| NaiveDateTime::from_timestamp(tx.timestamp as i64, 0));
-            let date = dt.date();
-            let amount = value_to_f64(tx.value);
-            let (deposit, withdrawal, description, account) = if tx.to == Some(address) {
-                let desc = tx
-                    .from_tag
-                    .as_deref()
-                    .map(|t| format!("from {t}"))
-                    .unwrap_or_else(|| "deposit".to_string());
-                let acc = tx.from_tag.clone().unwrap_or_else(|| "Unknown".to_string());
-                (Some(amount), None, desc, acc)
-            } else {
-                let desc = tx
-                    .to_tag
-                    .as_deref()
-                    .map(|t| format!("to {t}"))
-                    .unwrap_or_else(|| "withdrawal".to_string());
-                let acc = tx.to_tag.clone().unwrap_or_else(|| "Unknown".to_string());
-                (None, Some(amount), desc, acc)
-            };
+pub fn from_chain(address: Address, txs: &[blockchain::Transaction]) -> Vec<Split> {
+    let mut res = Vec::new();
+    for tx in txs {
+        let dt = NaiveDateTime::from_timestamp_opt(tx.timestamp as i64, 0)
+            .unwrap_or_else(|| NaiveDateTime::from_timestamp(tx.timestamp as i64, 0));
+        let date = dt.date();
+        let eth_amount = value_to_f64(tx.value, 18);
 
-            Transaction {
-                date,
-                description,
-                account,
-                deposit,
-                withdrawal,
+        let (description, account) = if tx.to == Some(address) {
+            let desc = tx
+                .from_tag
+                .as_deref()
+                .map(|t| format!("from {t}"))
+                .unwrap_or_else(|| "deposit".to_string());
+            let acc = tx.from_tag.clone().unwrap_or_else(|| "Unknown".to_string());
+            (desc, acc)
+        } else {
+            let desc = tx
+                .to_tag
+                .as_deref()
+                .map(|t| format!("to {t}"))
+                .unwrap_or_else(|| "withdrawal".to_string());
+            let acc = tx.to_tag.clone().unwrap_or_else(|| "Unknown".to_string());
+            (desc, acc)
+        };
+
+        if eth_amount != 0.0 {
+            let mut amount = eth_amount;
+            if tx.from == address {
+                amount = -amount;
             }
-        })
-        .collect()
+            res.push(Split {
+                date,
+                description: description.clone(),
+                account: account.clone(),
+                commodity: "ETH".to_string(),
+                value: amount,
+                amount,
+            });
+        }
+
+        for tr in &tx.transfers {
+            let decimals = tr.token_decimal.parse::<u32>().unwrap_or(18);
+            let mut amount = value_to_f64(tr.value, decimals);
+            if tr.from == address {
+                amount = -amount;
+            }
+            res.push(Split {
+                date,
+                description: description.clone(),
+                account: account.clone(),
+                commodity: tr.token_symbol.clone(),
+                value: amount,
+                amount,
+            });
+        }
+    }
+    res
 }
 
 /// Write the provided transactions to `path` in CSV format compatible with GnuCash
-pub fn write_csv(path: &Path, txs: &[Transaction]) -> Result<(), Box<dyn Error>> {
+pub fn write_csv(path: &Path, txs: &[Split]) -> Result<(), Box<dyn Error>> {
     let file = File::create(path)?;
     let mut wtr = Writer::from_writer(file);
-    wtr.write_record(["Date", "Description", "Account", "Deposit", "Withdrawal"])?;
+    wtr.write_record(["Date", "Description", "Account", "Commodity", "Value", "Amount"])?;
     for tx in txs {
         wtr.write_record([
             tx.date.to_string(),
             tx.description.clone(),
             tx.account.clone(),
-            tx.deposit.map(|v| v.to_string()).unwrap_or_default(),
-            tx.withdrawal.map(|v| v.to_string()).unwrap_or_default(),
+            tx.commodity.clone(),
+            tx.value.to_string(),
+            tx.amount.to_string(),
         ])?;
     }
     wtr.flush()?;
@@ -83,11 +109,21 @@ pub fn write_csv(path: &Path, txs: &[Transaction]) -> Result<(), Box<dyn Error>>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blockchain::Transaction as ChainTx;
+    use crate::blockchain::{Erc20Transfer, Transaction as ChainTx};
     use ethers::types::{H256, U256};
 
     #[test]
     fn conversion_sets_fields() {
+        let transfer = Erc20Transfer {
+            token_contract: Address::zero(),
+            from: Address::repeat_byte(0x11),
+            to: Some(Address::repeat_byte(0x22)),
+            value: U256::from(5u64),
+            token_name: "TEST".to_string(),
+            token_symbol: "TST".to_string(),
+            token_decimal: "18".to_string(),
+        };
+
         let chain_tx = ChainTx {
             hash: H256::zero(),
             block_number: 1,
@@ -97,11 +133,14 @@ mod tests {
             value: U256::from(10u64.pow(18)),
             from_tag: Some("alice".to_string()),
             to_tag: Some("bob".to_string()),
-            transfers: Vec::new(),
+            transfers: vec![transfer],
         };
-        let res = from_chain(Address::repeat_byte(0x22), &[chain_tx]);
-        assert_eq!(res[0].deposit.unwrap(), 1.0);
-        assert!(res[0].withdrawal.is_none());
-        assert_eq!(res[0].account, "alice");
+        let res = from_chain(Address::repeat_byte(0x11), &[chain_tx]);
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].commodity, "ETH");
+        assert!(res[0].value < 0.0);
+        assert_eq!(res[1].commodity, "TST");
+        assert!(res[1].value < 0.0);
+        assert_eq!(res[0].account, "bob");
     }
 }


### PR DESCRIPTION
## Summary
- export token transfers as separate splits with commodity and amounts
- output negative values when originating address matches sender
- update CSV headers and tests

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_688139665020832b9b26b4658ce9574f