### PR TITLE
Add description field to categories

### DIFF
--- a/categories.toml
+++ b/categories.toml
@@ -1,0 +1,43 @@
+["0x9dda6ef3d919c9bc8885d5560999a3640431e8e6"]
+category = "Swap"
+description = "Swap"
+
+["0x63dfa7c09dc2ff4030d6b8dc2ce6262bf898c8a4"]
+category = "Swap"
+description = "AAVE"
+
+["0x794a61358d6845594f94dc1db02a252b5b4814ad"]
+category = "Swap"
+description = "AAVE"
+
+["0xf3c3f14dd7bdb7e03e6ebc3bc5ffc6d66de12251"]
+category = "Swap"
+description = "AAVE"
+
+["0x5283beced7adf6d003225c13896e536f2d4264ff"]
+category = "Swap"
+description = "AAVE"
+
+["0x5760e34c4003752329bc77790b1de44c2799f8c3"]
+category = "Swap"
+description = "AAVE"
+
+["0x82af49447d8a07e3bd95bd0d56f35241523fbab1"]
+category = "Swap"
+description = "AAVE"
+
+["0x900173a66dbd345006c51fa35fa3ab760fcd843b"]
+category = "Trade"
+description = "GMX"
+
+["0x5ac4e27341e4cccb3e5fd62f9e62db2adf43dd57"]
+category = "Trade"
+description = "GMX"
+
+["0x69c527fc77291722b52649e45c838e41be8bf5d5"]
+category = "Trade"
+description = "GMX"
+
+["0x8704ee9ab8622bbc25410c7d4717ed51f776c7f6"]
+category = "Airdrop"
+description = "Airdrop"

--- a/examples/categories.sample.toml
+++ b/examples/categories.sample.toml
@@ -1,3 +1,8 @@
 # Mapping of addresses to transaction categories
-"0x1111111111111111111111111111111111111111" = "Deposit"
-"0x2222222222222222222222222222222222222222" = "Withdrawal"
+["0x1111111111111111111111111111111111111111"]
+category = "Deposit"
+description = "Sample deposit"
+
+["0x2222222222222222222222222222222222222222"]
+category = "Withdrawal"
+description = "Sample withdrawal"

--- a/importer/src/export.rs
+++ b/importer/src/export.rs
@@ -39,7 +39,11 @@ pub fn from_chain(address: Address, txs: &[blockchain::Transaction]) -> Vec<Spli
         } else {
             "withdrawal".to_string()
         };
-        let description = tx.category.clone().unwrap_or_else(|| default_desc.clone());
+        let description = tx
+            .description
+            .clone()
+            .or_else(|| tx.category.clone())
+            .unwrap_or_else(|| default_desc.clone());
         let account = tx.category.clone().unwrap_or_else(|| "Unknown".to_string());
 
         if eth_amount != 0.0 {
@@ -129,14 +133,15 @@ mod tests {
             to: Some(Address::repeat_byte(0x22)),
             value: U256::from(10u64.pow(18)),
             category: Some("Trade".to_string()),
+            description: None,
             transfers: vec![transfer],
         };
         let res = from_chain(Address::repeat_byte(0x11), &[chain_tx]);
         assert_eq!(res.len(), 2);
         assert_eq!(res[0].commodity, "ETH");
-        assert!(res[0].value < 0.0);
+        assert!(res[0].amount < 0.0);
         assert_eq!(res[1].commodity, "USDC");
-        assert!(res[1].value < 0.0);
+        assert!(res[1].amount < 0.0);
         assert_eq!(res[0].account, "Trade");
     }
 }


### PR DESCRIPTION
## Summary
- extend transaction categorization with description support
- update category parsing to handle descriptions
- update export logic to use new description field
- refresh tests for new structures
- provide example categories and sample mapping

## Testing
- `cargo fmt --all`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688cfb2f8dc8832bb638ee9ee4a838c6