### PR TITLE
Add debug export of token transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ You can provide a mapping of addresses to transaction categories using the `--ca
 0x2222222222222222222222222222222222222222: Withdrawal
 ```
 See [examples/categories.sample.toml](examples/categories.sample.toml) for a TOML example.
+
+You can also dump all detected ERC-20 token transfers by specifying `--transfers-output <PATH>` when running the backend. This writes a CSV file listing every transfer for debugging purposes.

--- a/importer/src/bin/backend.rs
+++ b/importer/src/bin/backend.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use arb_gnucash_importer::blockchain::{self, apply_categories, Categories, Config};
-use arb_gnucash_importer::export::{self, write_csv};
+use arb_gnucash_importer::export::{self, write_csv, write_transfers_csv};
 use ethers::types::Address;
 
 /// Command line arguments for the backend tool
@@ -21,6 +21,10 @@ struct Args {
     /// Optional config file mapping addresses to transaction categories
     #[arg(long)]
     categories: Option<PathBuf>,
+
+    /// Optional file path to write token transfer details
+    #[arg(long)]
+    transfers_output: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -41,5 +45,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
     let gnucash_txs = export::from_chain(address, &txs);
     write_csv(&args.output, &gnucash_txs)?;
+    if let Some(path) = args.transfers_output.as_deref() {
+        write_transfers_csv(path, &txs)?;
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a new CSV writer to export all token transfers
- support `--transfers-output` in the backend
- document how to use the new flag in README
- test writing the transfers CSV

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_688d10f9f114832bb645bb75aed7a81c